### PR TITLE
Rename master to main

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,20 +5,20 @@ SciPy pull request guidelines
 Pull requests are always welcome, and the SciPy community appreciates
 any help you give. Note that a code of conduct applies to all spaces
 managed by the SciPy project, including issues and pull requests:
-https://github.com/scipy/scipy/blob/master/doc/source/dev/conduct/code_of_conduct.rst.
+https://github.com/scipy/scipy/blob/main/doc/source/dev/conduct/code_of_conduct.rst.
 
 When submitting a pull request, we ask you check the following:
 
 1. **Unit tests**, **documentation**, and **code style** are in order.
    For details, please read
-   https://github.com/scipy/scipy/blob/master/HACKING.rst.txt
+   https://github.com/scipy/scipy/blob/main/HACKING.rst.txt
 
    It's also OK to submit work in progress if you're unsure of what
    this exactly means, in which case you'll likely be asked to make
    some further changes.
 
 2. The contributed code will be **licensed under SciPy's license**,
-   https://github.com/scipy/scipy/blob/master/LICENSE.txt
+   https://github.com/scipy/scipy/blob/main/LICENSE.txt
    If you did not write the code yourself, you ensure the existing
    license is compatible and include the license information in the
    contributed files, or obtain a permission from the original


### PR DESCRIPTION
This is for after @rgommers renames the master branch main.