### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,3 @@
+github: [numfocus]
 tidelift: pypi/scipy
-custom: https://scipy.org/donations/
+custom: https://opencollective.com/scipy


### PR DESCRIPTION
Fix link to donations, now on Open Collective. Add the NumFOCUS GitHub Sponsors link.