### PR TITLE
DOC: fix security link to Tidelift

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,6 @@
-To report a security vulnerability to SciPy, please go to
-https://scipy.github.io/devdocs/tutorial/security.html
-and see the instructions there.
+To report a security vulnerability to SciPy, please first carefully read
+[SciPy's Security guidance](https://scipy.github.io/devdocs/tutorial/security.html).
+If after that you want to report a security vulnerability, please use the
+[Tidelift security contact](https://tidelift.com/security).
+Tidelift will help coordinate the investigation by maintainers and, if needed,
+the fix and disclosure.


### PR DESCRIPTION
This link got removed recently in gh-5, but is necessary.